### PR TITLE
Fix QRCode load by switching to jsDelivr CDN

### DIFF
--- a/qrcode.html
+++ b/qrcode.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>QR Code Generator</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcode/1.5.3/qrcode.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
     <style>
         :root {
             --bg-color: #f4f6f8;


### PR DESCRIPTION
The cdnjs path for qrcode@1.5.3 returns 403, so the QRCode global
never loads. Use the jsDelivr URL for the same npm package instead.

https://claude.ai/code/session_01KNzvAsz8x9ms1UygWadCM9